### PR TITLE
Refactor Razor front-end to use shared layout and modular assets

### DIFF
--- a/Pages/LogIn.cshtml
+++ b/Pages/LogIn.cshtml
@@ -1,126 +1,36 @@
-﻿@page
+@page
 @model global::GarageDoorsWeb.Pages.LoginModel
 @{
     ViewData["Title"] = "Login";
-    Layout = null;
+    Layout = "~/Pages/Shared/_Layout.cshtml";
 }
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login</title>
-    <!-- Include Bootstrap CSS -->
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        body {
-            background-color: #f8f9fa;
-        }
 
-        .login-container {
-            margin-top: 100px;
-            padding: 20px;
-            border-radius: 8px;
-            background-color: white;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        }
+@section Styles {
+    <link rel="stylesheet" href="~/css/login.css" asp-append-version="true" />
+}
 
-        .login-title {
-            margin-bottom: 20px;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-md-6 login-container">
-                <h2 class="login-title text-center">Login</h2>
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6 login-container">
+            <h2 class="login-title text-center">Login</h2>
 
-                <div id="error-message" class="alert alert-danger" style="display: none;"></div>
+            <div id="error-message" class="alert alert-danger" style="display: none;"></div>
 
-                <!-- Login Form -->
-                <form id="loginForm">
-                    <div class="form-group">
-                        <label for="username">Username</label>
-                        <input type="text" class="form-control" id="username" name="username" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="password">Password</label>
-                        <input type="password" class="form-control" id="password" name="password" required>
-                    </div>
-                    <button type="button" class="btn btn-primary btn-block" onclick="login()">Login</button>
-                </form>
-                <!-- End Login Form -->
-            </div>
+            <form id="loginForm">
+                <div class="form-group">
+                    <label for="username">Username</label>
+                    <input type="text" class="form-control" id="username" name="username" required>
+                </div>
+                <div class="form-group">
+                    <label for="password">Password</label>
+                    <input type="password" class="form-control" id="password" name="password" required>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Login</button>
+            </form>
         </div>
     </div>
+</div>
 
-    <script>
-        function login() {
-            var username = document.getElementById("username").value;
-            var password = document.getElementById("password").value;
-
-            fetch('/login', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                },
-                body: `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`
-            })
-                .then(response => {
-                    if (!response.ok) {
-                        return response.text().then(text => { throw new Error(text) });
-                    }
-                    return response.json();
-                })
-                .then(data => {
-                    console.log('Server response:', data); // Add logging
-
-                    // Redirect to the desired page
-                    if (data.redirectUrl) {
-                        window.location.href = data.redirectUrl;
-                    } else {
-                        alert('Login successful, but no redirect URL provided.');
-                    }
-                })
-                .catch(error => {
-                    console.error('Error:', error); // Add logging
-                    var errorMessage = document.getElementById("error-message");
-                    errorMessage.textContent = error.message || 'Login failed!';
-                    errorMessage.style.display = 'block';
-                });
-        }
-
-        function getCookie(name) {
-            const value = `; ${document.cookie}`;
-            const parts = value.split(`; ${name}=`);
-            if (parts.length === 2) return parts.pop().split(';').shift();
-        }
-
-        function authenticatedRequest(url, options = {}) {
-            const token = getCookie('jwt');
-            if (!options.headers) {
-                options.headers = {};
-            }
-            options.headers['Authorization'] = `Bearer ${token}`;
-            return fetch(url, options);
-        }
-
-        // Example usage:
-        // document.addEventListener('DOMContentLoaded', () => {
-        //     authenticatedRequest('/protected-endpoint', {
-        //         method: 'GET'
-        //     }).then(response => {
-        //         if (!response.ok) {
-        //             throw new Error('Failed to fetch protected resource');
-        //         }
-        //         return response.json();
-        //     }).then(data => {
-        //         console.log(data);
-        //     }).catch(error => {
-        //         console.error('Error:', error);
-        //     });
-        // });
-    </script>
-</body>
-</html>
+@section Scripts {
+    <script src="~/js/login.js" asp-append-version="true"></script>
+}

--- a/Pages/ManageUsers.cshtml
+++ b/Pages/ManageUsers.cshtml
@@ -1,142 +1,111 @@
-﻿@page
+@page
 @model GarageDoorsWeb.Pages.ManageUsersModel
 @{
     ViewData["Title"] = "Manage Users";
     Layout = "~/Pages/Shared/_Layout.cshtml";
 }
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Manage Users</title>
-    <!-- Include Bootstrap CSS -->
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        body {
-            background-color: #f8f9fa;
-        }
 
-        .container2 {
-            margin-top: 30px;
-            padding-bottom: 55px;
-        }
+@section Styles {
+    <link rel="stylesheet" href="~/css/manage-users.css" asp-append-version="true" />
+}
 
-        .section-title {
-            margin-bottom: 20px;
-            color: #343a40;
-        }
-
-        .form-inline .form-control {
-            width: auto;
-        }
-    </style>
-</head>
-<body>
-    <div class="container2">
-        <!-- Users Created By You -->
-        <div class="card mb-4">
-            <div class="card-header">
-                <h2 class="section-title">Users Created By You</h2>
-            </div>
-            <div class="card-body">
-                <table class="table table-bordered table-hover">
-                    <thead class="thead-light">
+<div class="container2">
+    <!-- Users Created By You -->
+    <div class="card mb-4">
+        <div class="card-header">
+            <h2 class="section-title">Users Created By You</h2>
+        </div>
+        <div class="card-body">
+            <table class="table table-bordered table-hover">
+                <thead class="thead-light">
+                    <tr>
+                        <th>Username</th>
+                        <th>User ID</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var user in Model.Users)
+                    {
                         <tr>
-                            <th>Username</th>
-                            <th>User ID</th>
+                            <td>@user.Username</td>
+                            <td>@user.UserID</td>
                         </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var user in Model.Users)
-                        {
-                            <tr>
-                                <td>@user.Username</td>
-                                <td>@user.UserID</td>
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-            </div>
-        </div>
-
-        <!-- Create New User Form -->
-        <div class="card mb-4">
-            <div class="card-header">
-                <h2 class="section-title">Create New User</h2>
-            </div>
-            <div class="card-body">
-                <form method="post" asp-page-handler="AddUser" class="form-inline">
-                    <div class="form-group mr-2">
-                        <label for="username" class="sr-only">Username:</label>
-                        <input type="text" id="username" asp-for="NewUser.Username" class="form-control" placeholder="Username" />
-                    </div>
-                    <div class="form-group mr-2">
-                        <label for="password" class="sr-only">Password:</label>
-                        <input type="password" id="password" asp-for="NewUser.Password" class="form-control" placeholder="Password" />
-                    </div>
-                    <button type="submit" class="btn btn-success">Create User</button>
-                </form>
-            </div>
-        </div>
-
-        <!-- Assigned Users-Doors -->
-        <div class="card mb-4">
-            <div class="card-header">
-                <h2 class="section-title">Assigned Users-Doors</h2>
-            </div>
-            <div class="card-body">
-                <table class="table table-bordered table-hover">
-                    <thead class="thead-light">
-                        <tr>
-                            <th>Username</th>
-                            <th>UserID</th>
-                            <th>Door Name</th>
-                            <th>DoorID</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var userdoor in Model.UserAssignedDoors)
-                        {
-                            <tr>
-                                <td>@userdoor.User.Username</td>
-                                <td>@userdoor.User.UserID</td>
-                                <td>@userdoor.Door.DoorName</td>
-                                <td>@userdoor.Door.DoorID</td>
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-            </div>
-        </div>
-
-        <!-- Assignment Section -->
-        <div class="card mb-4">
-            <div class="card-header">
-                <h2 class="section-title">Assign or Unassign User to Door</h2>
-            </div>
-            <div class="card-body">
-                <form method="post">
-                    <div class="form-group">
-                        <label for="userSelect">Select User:</label>
-                        <select id="userSelect" asp-for="SelectedUserId" asp-items="@(new SelectList(Model.Users, "UserID", "Username"))" class="form-control"></select>
-                    </div>
-                    <div class="form-group">
-                        <label for="doorSelect">Select Door:</label>
-                        <select id="doorSelect" asp-for="SelectedDoorId" asp-items="@(new SelectList(Model.UserDoorsList, "DoorID", "DoorName"))" class="form-control"></select>
-                    </div>
-                    <div class="d-flex justify-content-between">
-                        <button type="submit" asp-page-handler="AssignUserToDoor" class="btn btn-primary">Assign</button>
-                        <button type="submit" asp-page-handler="UnassignUserFromDoor" class="btn btn-warning">Unassign</button>
-                    </div>
-                </form>
-            </div>
+                    }
+                </tbody>
+            </table>
         </div>
     </div>
 
-    <!-- Include Bootstrap JS and dependencies -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.3/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-</body>
-</html>
+    <!-- Create New User Form -->
+    <div class="card mb-4">
+        <div class="card-header">
+            <h2 class="section-title">Create New User</h2>
+        </div>
+        <div class="card-body">
+            <form method="post" asp-page-handler="AddUser" class="form-inline">
+                <div class="form-group mr-2">
+                    <label for="username" class="sr-only">Username:</label>
+                    <input type="text" id="username" asp-for="NewUser.Username" class="form-control" placeholder="Username" />
+                </div>
+                <div class="form-group mr-2">
+                    <label for="password" class="sr-only">Password:</label>
+                    <input type="password" id="password" asp-for="NewUser.Password" class="form-control" placeholder="Password" />
+                </div>
+                <button type="submit" class="btn btn-success">Create User</button>
+            </form>
+        </div>
+    </div>
+
+    <!-- Assigned Users-Doors -->
+    <div class="card mb-4">
+        <div class="card-header">
+            <h2 class="section-title">Assigned Users-Doors</h2>
+        </div>
+        <div class="card-body">
+            <table class="table table-bordered table-hover">
+                <thead class="thead-light">
+                    <tr>
+                        <th>Username</th>
+                        <th>UserID</th>
+                        <th>Door Name</th>
+                        <th>DoorID</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var userdoor in Model.UserAssignedDoors)
+                    {
+                        <tr>
+                            <td>@userdoor.User.Username</td>
+                            <td>@userdoor.User.UserID</td>
+                            <td>@userdoor.Door.DoorName</td>
+                            <td>@userdoor.Door.DoorID</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Assignment Section -->
+    <div class="card mb-4">
+        <div class="card-header">
+            <h2 class="section-title">Assign or Unassign User to Door</h2>
+        </div>
+        <div class="card-body">
+            <form method="post">
+                <div class="form-group">
+                    <label for="userSelect">Select User:</label>
+                    <select id="userSelect" asp-for="SelectedUserId" asp-items="@(new SelectList(Model.Users, "UserID", "Username"))" class="form-control"></select>
+                </div>
+                <div class="form-group">
+                    <label for="doorSelect">Select Door:</label>
+                    <select id="doorSelect" asp-for="SelectedDoorId" asp-items="@(new SelectList(Model.UserDoorsList, "DoorID", "DoorName"))" class="form-control"></select>
+                </div>
+                <div class="d-flex justify-content-between">
+                    <button type="submit" asp-page-handler="AssignUserToDoor" class="btn btn-primary">Assign</button>
+                    <button type="submit" asp-page-handler="UnassignUserFromDoor" class="btn btn-warning">Unassign</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -9,69 +9,8 @@
     <!-- Include Font Awesome for icons -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="~/dist/main.css" asp-append-version="true" />
-    <style>
-        body {
-            background-color: #f8f9fa;
-            display: flex;
-            flex-direction: column;
-            min-height: 100vh;
-        }
-
-        .container {
-            flex: 1;
-            margin-top: 30px;
-            padding-bottom: 30px;
-        }
-
-        .navbar {
-            padding: 1rem 1rem;
-            background-color: #ffffff;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-
-        .navbar-brand {
-            font-weight: bold;
-            color: #007bff;
-        }
-
-            .navbar-brand:hover {
-                color: #0056b3;
-            }
-
-        .navbar-nav .nav-link {
-            color: #343a40;
-            font-weight: 500;
-        }
-
-            .navbar-nav .nav-link:hover {
-                color: #0056b3;
-            }
-
-        .navbar-nav .nav-item .btn-link {
-            color: #343a40;
-        }
-
-            .navbar-nav .nav-item .btn-link:hover {
-                color: #0056b3;
-            }
-
-        .footer {
-            background-color: #f8f9fa;
-            padding: 10px 0;
-            text-align: center;
-            border-top: 1px solid #e4e4e4;
-            margin-top: auto;
-        }
-
-            .footer a {
-                color: #007bff;
-                text-decoration: none;
-            }
-
-                .footer a:hover {
-                    color: #0056b3;
-                }
-    </style>
+    <link rel="stylesheet" href="~/css/layout.css" asp-append-version="true" />
+    @RenderSection("Styles", required: false)
 </head>
 <body>
     <header>

--- a/wwwroot/css/layout.css
+++ b/wwwroot/css/layout.css
@@ -1,0 +1,61 @@
+body {
+    background-color: #f8f9fa;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.container {
+    flex: 1;
+    margin-top: 30px;
+    padding-bottom: 30px;
+}
+
+.navbar {
+    padding: 1rem 1rem;
+    background-color: #ffffff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.navbar-brand {
+    font-weight: bold;
+    color: #007bff;
+}
+
+.navbar-brand:hover {
+    color: #0056b3;
+}
+
+.navbar-nav .nav-link {
+    color: #343a40;
+    font-weight: 500;
+}
+
+.navbar-nav .nav-link:hover {
+    color: #0056b3;
+}
+
+.navbar-nav .nav-item .btn-link {
+    color: #343a40;
+}
+
+.navbar-nav .nav-item .btn-link:hover {
+    color: #0056b3;
+}
+
+.footer {
+    background-color: #f8f9fa;
+    padding: 10px 0;
+    text-align: center;
+    border-top: 1px solid #e4e4e4;
+    margin-top: auto;
+}
+
+.footer a {
+    color: #007bff;
+    text-decoration: none;
+}
+
+.footer a:hover {
+    color: #0056b3;
+}

--- a/wwwroot/css/login.css
+++ b/wwwroot/css/login.css
@@ -1,0 +1,11 @@
+.login-container {
+    margin-top: 100px;
+    padding: 20px;
+    border-radius: 8px;
+    background-color: white;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.login-title {
+    margin-bottom: 20px;
+}

--- a/wwwroot/css/manage-users.css
+++ b/wwwroot/css/manage-users.css
@@ -1,0 +1,13 @@
+.container2 {
+    margin-top: 30px;
+    padding-bottom: 55px;
+}
+
+.section-title {
+    margin-bottom: 20px;
+    color: #343a40;
+}
+
+.form-inline .form-control {
+    width: auto;
+}

--- a/wwwroot/js/login.js
+++ b/wwwroot/js/login.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('loginForm');
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        await login();
+    });
+});
+
+async function login() {
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+
+    try {
+        const response = await fetch('/login', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`
+        });
+
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text);
+        }
+
+        const data = await response.json();
+        if (data.redirectUrl) {
+            window.location.href = data.redirectUrl;
+        } else {
+            alert('Login successful, but no redirect URL provided.');
+        }
+    } catch (error) {
+        console.error('Error:', error);
+        const errorMessage = document.getElementById('error-message');
+        errorMessage.textContent = error.message || 'Login failed!';
+        errorMessage.style.display = 'block';
+    }
+}
+
+function getCookie(name) {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) return parts.pop().split(';').shift();
+}
+
+function authenticatedRequest(url, options = {}) {
+    const token = getCookie('jwt');
+    if (!options.headers) {
+        options.headers = {};
+    }
+    options.headers['Authorization'] = `Bearer ${token}`;
+    return fetch(url, options);
+}


### PR DESCRIPTION
## Summary
- Simplify Manage Users and Login pages to rely on the shared layout
- Move inline styles into `wwwroot/css` and modularize login JavaScript
- Add `layout.css` and expose a `Styles` section for page-specific CSS

## Testing
- `dotnet build`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899b66f118c832c8e9ba18bfb22c247